### PR TITLE
Improve arrival info model and API usage

### DIFF
--- a/SubwayArrivalFlutterApp/README.md
+++ b/SubwayArrivalFlutterApp/README.md
@@ -10,6 +10,22 @@
 1. Flutter 환경을 준비합니다.
 2. `pubspec.yaml`의 의존성을 설치합니다: `flutter pub get`
 3. `lib/` 폴더의 소스를 플러터 프로젝트에 복사하거나 그대로 실행합니다.
-4. `subway_service.dart`에는 예시용 키(`596c69597774616536325742684e64`)가 미리 설정되어 있습니다. 실제 서비스 시에는 본인의 키로 교체한 후 빌드합니다.
+4. `lib/services/api_key.dart` 파일에는 기본 API 키가 정의되어 있습니다. 실제 서비스 시에는 `--dart-define SUBWAY_API_KEY=<YOUR_KEY>` 옵션을 사용하거나 파일을 수정해 본인의 키로 교체한 후 빌드합니다.
+
+## API 요청 형식
+
+API 호출은 다음과 같은 경로 형식을 사용합니다.
+
+```
+https://swopenAPI.seoul.go.kr/api/subway/{KEY}/{TYPE}/{SERVICE}/{START_INDEX}/{END_INDEX}/{statnNm}
+```
+
+- `KEY`: 발급받은 인증키
+- `TYPE`: 응답 형식 (`json`, `xml` 등)
+- `SERVICE`: 서비스명(실시간 도착 정보는 `realtimeStationArrival`)
+- `START_INDEX`, `END_INDEX`: 조회할 데이터 범위
+- `statnNm`: 역 이름
+
+`SubwayService.fetchArrivalInfo` 함수는 위 인자를 사용해 URL을 생성합니다.
 
 실제 앱 배포 시 네트워크 오류 처리 등 추가 작업이 필요합니다.

--- a/SubwayArrivalFlutterApp/lib/models/arrival_info.dart
+++ b/SubwayArrivalFlutterApp/lib/models/arrival_info.dart
@@ -1,13 +1,73 @@
 class ArrivalInfo {
+  final String subwayId;
+  final String updnLine;
   final String trainLineName;
+  final String statnFid;
+  final String statnTid;
+  final String statnId;
+  final String statnNm;
+  final String trnsitCo;
+  final String ordkey;
+  final String subwayList;
+  final String statnList;
+  final String btrainSttus;
+  final String barvlDt;
+  final String btrainNo;
+  final String bstatnId;
+  final String bstatnNm;
+  final String recptnDt;
   final String arrivalMessage;
+  final String arrivalMessage3;
+  final String arrivalCode;
+  final String lastTrain;
 
-  ArrivalInfo({required this.trainLineName, required this.arrivalMessage});
+  ArrivalInfo({
+    required this.subwayId,
+    required this.updnLine,
+    required this.trainLineName,
+    required this.statnFid,
+    required this.statnTid,
+    required this.statnId,
+    required this.statnNm,
+    required this.trnsitCo,
+    required this.ordkey,
+    required this.subwayList,
+    required this.statnList,
+    required this.btrainSttus,
+    required this.barvlDt,
+    required this.btrainNo,
+    required this.bstatnId,
+    required this.bstatnNm,
+    required this.recptnDt,
+    required this.arrivalMessage,
+    required this.arrivalMessage3,
+    required this.arrivalCode,
+    required this.lastTrain,
+  });
 
   factory ArrivalInfo.fromJson(Map<String, dynamic> json) {
     return ArrivalInfo(
+      subwayId: json['subwayId'].toString(),
+      updnLine: json['updnLine'] as String,
       trainLineName: json['trainLineNm'] as String,
+      statnFid: json['statnFid'].toString(),
+      statnTid: json['statnTid'].toString(),
+      statnId: json['statnId'].toString(),
+      statnNm: json['statnNm'] as String,
+      trnsitCo: json['trnsitCo'].toString(),
+      ordkey: json['ordkey'] as String,
+      subwayList: json['subwayList'] as String,
+      statnList: json['statnList'] as String,
+      btrainSttus: json['btrainSttus'] as String? ?? '',
+      barvlDt: json['barvlDt'].toString(),
+      btrainNo: json['btrainNo'] as String? ?? '',
+      bstatnId: json['bstatnId'].toString(),
+      bstatnNm: json['bstatnNm'] as String? ?? '',
+      recptnDt: json['recptnDt'] as String,
       arrivalMessage: json['arvlMsg2'] as String,
+      arrivalMessage3: json['arvlMsg3'] as String? ?? '',
+      arrivalCode: json['arvlCd'].toString(),
+      lastTrain: json['lstcarAt'].toString(),
     );
   }
 }

--- a/SubwayArrivalFlutterApp/lib/screens/home_page.dart
+++ b/SubwayArrivalFlutterApp/lib/screens/home_page.dart
@@ -34,6 +34,11 @@ class _HomePageState extends State<HomePage> {
     setState(() {
       _arrivals = infos.take(2).toList();
     });
+    if (infos.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('도착 정보를 불러올 수 없습니다.')),
+      );
+    }
   }
 
   void _openSettings() async {
@@ -71,7 +76,7 @@ class _HomePageState extends State<HomePage> {
                 final info = _arrivals[i];
                 return ListTile(
                   title: Text(info.trainLineName),
-                  subtitle: Text(info.arrivalMessage),
+                  subtitle: Text('${info.arrivalMessage} / ${info.arrivalMessage3}'),
                 );
               },
             ),

--- a/SubwayArrivalFlutterApp/lib/services/api_key.dart
+++ b/SubwayArrivalFlutterApp/lib/services/api_key.dart
@@ -1,0 +1,4 @@
+const String subwayApiKey = String.fromEnvironment(
+  'SUBWAY_API_KEY',
+  defaultValue: '596c69597774616536325742684e64',
+);

--- a/SubwayArrivalFlutterApp/lib/services/subway_service.dart
+++ b/SubwayArrivalFlutterApp/lib/services/subway_service.dart
@@ -1,24 +1,33 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/arrival_info.dart';
+import 'api_key.dart';
 
 class SubwayService {
 
-  // 서울시 열린데이터 광장에서 발급받은 API 키
-  static const String _apiKey = '596c69597774616536325742684e64';
+  static Future<List<ArrivalInfo>> fetchArrivalInfo(
+    String station, {
+    int startIndex = 0,
+    int endIndex = 5,
+    String type = 'json',
+    String service = 'realtimeStationArrival',
+  }) async {
+    try {
+      final encoded = Uri.encodeComponent(station);
+      final url = Uri.parse(
+          'https://swopenAPI.seoul.go.kr/api/subway/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
 
-
-  static Future<List<ArrivalInfo>> fetchArrivalInfo(String station) async {
-    final encoded = Uri.encodeComponent(station);
-    final url = Uri.parse(
-        'https://swopenAPI.seoul.go.kr/api/subway/$_apiKey/json/realtimeStationArrival/0/2/$encoded');
-
-    final response = await http.get(url);
-    if (response.statusCode == 200) {
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
-      final List list = json['realtimeArrivalList'] as List;
-      return list.map((e) => ArrivalInfo.fromJson(e)).toList();
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        final List list = json['realtimeArrivalList'] as List;
+        return list.map((e) => ArrivalInfo.fromJson(e)).toList();
+      } else {
+        throw Exception('HTTP ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error fetching arrival info: $e');
+      return [];
     }
-    return [];
   }
 }


### PR DESCRIPTION
## Summary
- document official API request format
- expand `ArrivalInfo` model to map more API fields
- fetch arrival info with configurable parameters
- show secondary arrival message in UI

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852202d27fc832784bf13bec83873ae