### PR TITLE
Fix Subway API fetch issue

### DIFF
--- a/SubwayArrivalFlutterApp/README.md
+++ b/SubwayArrivalFlutterApp/README.md
@@ -11,6 +11,7 @@
 2. `pubspec.yaml`의 의존성을 설치합니다: `flutter pub get`
 3. `lib/` 폴더의 소스를 플러터 프로젝트에 복사하거나 그대로 실행합니다.
 4. `lib/services/api_key.dart` 파일에는 기본 API 키가 정의되어 있습니다. 실제 서비스 시에는 `--dart-define SUBWAY_API_KEY=<YOUR_KEY>` 옵션을 사용하거나 파일을 수정해 본인의 키로 교체한 후 빌드합니다.
+5. 웹 빌드 시 CORS 문제를 피하려면 `--dart-define SUBWAY_API_BASE_URL=<URL>` 로 API 서버 주소를 변경할 수 있습니다.
 
 
 ## API 요청 형식
@@ -28,7 +29,8 @@ https://swopenAPI.seoul.go.kr/api/subway/{KEY}/{TYPE}/{SERVICE}/{START_INDEX}/{E
 - `statnNm`: 역 이름
 
 `SubwayService.fetchArrivalInfo` 함수는 위 인자를 사용해 URL을 생성합니다.
-=======
-
 
 실제 앱 배포 시 네트워크 오류 처리 등 추가 작업이 필요합니다.
+네트워크 환경에 따라 API 서버 접근이 제한될 수 있으므로,
+`SUBWAY_API_BASE_URL` 값을 프록시 서버 등으로 변경하여 사용하면
+CORS 문제를 회피할 수 있습니다.

--- a/SubwayArrivalFlutterApp/lib/services/api_key.dart
+++ b/SubwayArrivalFlutterApp/lib/services/api_key.dart
@@ -2,3 +2,10 @@ const String subwayApiKey = String.fromEnvironment(
   'SUBWAY_API_KEY',
   defaultValue: '596c69597774616536325742684e64',
 );
+
+/// API 호출에 사용할 기본 URL.
+/// 환경 변수 `SUBWAY_API_BASE_URL` 로 재정의할 수 있습니다.
+const String subwayApiBaseUrl = String.fromEnvironment(
+  'SUBWAY_API_BASE_URL',
+  defaultValue: 'https://swopenAPI.seoul.go.kr/api/subway',
+);

--- a/SubwayArrivalFlutterApp/lib/services/subway_service.dart
+++ b/SubwayArrivalFlutterApp/lib/services/subway_service.dart
@@ -14,7 +14,7 @@ class SubwayService {
     try {
       final encoded = Uri.encodeComponent(station);
       final url = Uri.parse(
-          'https://swopenAPI.seoul.go.kr/api/subway/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
+          '$subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
 
       final response = await http.get(url);
       if (response.statusCode == 200) {
@@ -26,6 +26,7 @@ class SubwayService {
       }
     } catch (e) {
       print('Error fetching arrival info: $e');
+      print('Request URL: $subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
       return [];
     }
   }


### PR DESCRIPTION
## Summary
- allow overriding API base URL
- document `SUBWAY_API_BASE_URL` for using proxy servers
- log request URL when fetching arrival info fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852485082f8832790980f3b1b5ca31e