### PR TITLE
Fix encoded station name

### DIFF
--- a/SubwayArrivalFlutterApp/lib/services/subway_service.dart
+++ b/SubwayArrivalFlutterApp/lib/services/subway_service.dart
@@ -12,9 +12,8 @@ class SubwayService {
     String service = 'realtimeStationArrival',
   }) async {
     try {
-      final encoded = Uri.encodeComponent(station);
       final url = Uri.parse(
-          '$subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
+          '$subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$station');
 
       final response = await http.get(url);
       if (response.statusCode == 200) {
@@ -26,7 +25,7 @@ class SubwayService {
       }
     } catch (e) {
       print('Error fetching arrival info: $e');
-      print('Request URL: $subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$encoded');
+      print('Request URL: $subwayApiBaseUrl/$subwayApiKey/$type/$service/$startIndex/$endIndex/$station');
       return [];
     }
   }


### PR DESCRIPTION
## Summary
- pass station name directly without URI encoding

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524eb119488327a25b12a6afb34d17