### PR TITLE
Update Dart SDK constraint

### DIFF
--- a/SubwayArrivalFlutterApp/pubspec.yaml
+++ b/SubwayArrivalFlutterApp/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- support Dart 3 by updating SDK version in pubspec

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685266bf75d8832798a4bd4fcba9c8d6